### PR TITLE
fix: UI vbuiltin display and webadmin type assertion deduplication

### DIFF
--- a/internal/webadmin/templates/partials/settings_tools.html
+++ b/internal/webadmin/templates/partials/settings_tools.html
@@ -5,7 +5,7 @@
 <div class="settings-section">
     <div class="flex items-center gap-2 mb-3">
         <h3 class="settings-section-title mb-0">{{.ID}}</h3>
-        {{if .Version}}<span class="text-xs text-warm-400">v{{.Version}}</span>{{end}}
+        {{if .Version}}<span class="text-xs text-warm-400">{{if eq .Version "builtin"}}{{.Version}}{{else}}v{{.Version}}{{end}}</span>{{end}}
         <span class="text-xs text-warm-400">({{len .Tools}} tools)</span>
     </div>
     <div class="border border-warm-200 rounded-lg overflow-hidden">

--- a/internal/webadmin/templates/partials/tools_list.html
+++ b/internal/webadmin/templates/partials/tools_list.html
@@ -19,7 +19,7 @@
                     <p class="text-xs text-warm-400">{{len .Tools}} tool{{if ne (len .Tools) 1}}s{{end}} registered</p>
                 </div>
             </div>
-            {{if .Version}}<span class="px-2 py-0.5 text-xs rounded-full bg-forest/10 text-forest">v{{.Version}}</span>{{end}}
+            {{if .Version}}<span class="px-2 py-0.5 text-xs rounded-full bg-forest/10 text-forest">{{if eq .Version "builtin"}}{{.Version}}{{else}}v{{.Version}}{{end}}</span>{{end}}
         </div>
         {{if .Tools}}
         <div class="mt-3 space-y-2">

--- a/internal/webadmin/webadmin.go
+++ b/internal/webadmin/webadmin.go
@@ -134,6 +134,18 @@ type Admin struct {
 	tokenGenerator   TokenGenerator
 }
 
+// getSQLiteStore returns the underlying SQLiteStore if available.
+// Returns nil and logs an error if the store is not a SQLiteStore.
+// This helper deduplicates the type assertion pattern used across secrets handlers.
+func (a *Admin) getSQLiteStore() *store.SQLiteStore {
+	sqlStore, ok := a.store.(*store.SQLiteStore)
+	if !ok {
+		a.logger.Error("store is not SQLiteStore")
+		return nil
+	}
+	return sqlStore
+}
+
 // NewConfig contains dependencies for creating Admin.
 type NewConfig struct {
 	Store          FullStore
@@ -2094,10 +2106,8 @@ func (a *Admin) handleSecretsPage(w http.ResponseWriter, r *http.Request) {
 
 // handleSecretsList returns the secrets list (htmx partial).
 func (a *Admin) handleSecretsList(w http.ResponseWriter, r *http.Request) {
-	// Type assert to SQLiteStore to access secrets methods
-	sqlStore, ok := a.store.(*store.SQLiteStore)
-	if !ok {
-		a.logger.Error("store is not SQLiteStore")
+	sqlStore := a.getSQLiteStore()
+	if sqlStore == nil {
 		http.Error(w, "Server configuration error", http.StatusInternalServerError)
 		return
 	}
@@ -2152,9 +2162,8 @@ func (a *Admin) handleSecretsGetValue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Type assert to SQLiteStore
-	sqlStore, ok := a.store.(*store.SQLiteStore)
-	if !ok {
+	sqlStore := a.getSQLiteStore()
+	if sqlStore == nil {
 		http.Error(w, "Server configuration error", http.StatusInternalServerError)
 		return
 	}
@@ -2235,8 +2244,8 @@ func (a *Admin) handleSecretsCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sqlStore, ok := a.store.(*store.SQLiteStore)
-	if !ok {
+	sqlStore := a.getSQLiteStore()
+	if sqlStore == nil {
 		http.Error(w, "Server configuration error", http.StatusInternalServerError)
 		return
 	}
@@ -2288,9 +2297,8 @@ func (a *Admin) handleSecretsUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Type assert to SQLiteStore
-	sqlStore, ok := a.store.(*store.SQLiteStore)
-	if !ok {
+	sqlStore := a.getSQLiteStore()
+	if sqlStore == nil {
 		http.Error(w, "Server configuration error", http.StatusInternalServerError)
 		return
 	}
@@ -2334,9 +2342,8 @@ func (a *Admin) handleSecretsDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Type assert to SQLiteStore
-	sqlStore, ok := a.store.(*store.SQLiteStore)
-	if !ok {
+	sqlStore := a.getSQLiteStore()
+	if sqlStore == nil {
 		http.Error(w, "Server configuration error", http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
## Summary

- **Issue #1**: Fixed UI showing "vbuiltin" instead of "builtin" for builtin tool packs
- **Issue #7** (partial): Added `getSQLiteStore()` helper to deduplicate 5 repeated type assertions in webadmin secrets handlers

## Changes

### Issue #1 - UI "vbuiltin" Display
Templates unconditionally prepended "v" to version strings, producing "vbuiltin" for builtin packs. Now conditionally skips the "v" prefix when version equals "builtin".

**Files changed:**
- `internal/webadmin/templates/partials/tools_list.html`
- `internal/webadmin/templates/partials/settings_tools.html`

### Issue #7 - Code Quality (Webadmin Type Assertions)
Added `getSQLiteStore()` helper method to centralize the repeated pattern:
```go
sqlStore, ok := a.store.(*store.SQLiteStore)
if !ok {
    a.logger.Error("store is not SQLiteStore")
    http.Error(w, "Server configuration error", http.StatusInternalServerError)
    return
}
```

This deduplicates 5 occurrences across secrets handlers.

### Already Fixed (found during investigation)
Other Issue #7 items were already addressed in previous PRs:
- ✅ Custom `contains()` → not found
- ✅ Router close count logging → already captures count before clear
- ✅ Deprecated `strings.Title` → not found  
- ✅ Regex compiled per call → already package-level var
- ✅ Issue #2 (unchecked type assertions) → fixed in PR #37

## Test plan
- [x] All tests pass (`go test ./...`)
- [x] golangci-lint passes with comprehensive config
- [x] Pre-commit hooks pass
- [ ] Manual verification: check Tools page shows "builtin" (not "vbuiltin")

## Prevention Measures Discussed (PAL Consensus)

Based on multi-model consensus analysis, these barriers help prevent recurrence:

**Hard barriers (already in place):**
- `golangci-lint` with `errchkjson`, `errorlint`, `forcetypeassert`, `staticcheck`
- Pre-commit hooks run tests and linting

**Soft barriers (recommended for CLAUDE.md):**
- Code review checklist: "No unchecked type assertions; prefer helper methods"
- Prefer stdlib helpers (`strings.Contains`) over custom implementations
- Compile regexes once at package level

Closes #1
Partially addresses #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated version badge display formatting: "builtin" versions now display without the "v" prefix, while other versions retain the prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->