### PR TITLE
fix: remove dead build-tui target, add coding guidelines (#19)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 coven-gateway is the production control plane for coven agents. It manages coven-agent connections via gRPC, routes messages from frontends (HTTP clients, Matrix) to agents, and streams responses back in real-time.
 
-The coven-agent is a separate Rust project at `../coven-agent` that connects to this gateway. The shared protobuf definition is at `../coven-agent/proto/coven.proto`.
+The coven ecosystem spans multiple repositories:
+- **coven-gateway** (this repo) - Go control plane server
+- **[coven](https://github.com/2389-research/coven)** - Rust agent platform (`coven-agent`, `coven-tui`)
+- **[coven-proto](https://github.com/2389-research/coven-proto)** - Shared protobuf definitions (git submodule at `proto/coven-proto`)
 
 ## Getting Started
 
@@ -42,14 +45,13 @@ cp config.example.yaml config.yaml    # Create config from template
 ```bash
 make                    # Generate proto + build all binaries
 make build              # Build all binaries (without proto regen)
-make proto              # Regenerate protobuf from ../coven-agent/proto/coven.proto
+make proto              # Regenerate protobuf from proto/coven-proto/coven.proto
 make proto-deps         # Install protoc plugins (one-time)
 ```
 
 Individual binaries:
 ```bash
 go build -o bin/coven-gateway ./cmd/coven-gateway
-go build -o bin/coven-tui ./cmd/coven-tui
 go build -o bin/coven-admin ./cmd/coven-admin
 ```
 
@@ -74,9 +76,10 @@ golangci-lint run
 ```bash
 cp config.example.yaml config.yaml      # Copy config template
 ./bin/coven-gateway serve                # Start gateway (uses COVEN_CONFIG or ~/.config/coven/gateway.yaml)
-./bin/coven-tui                          # Interactive TUI client
-./bin/coven-admin -watch                 # Monitor status
+./bin/coven-admin status                 # Check gateway status
 ```
+
+For the interactive TUI client, install from the [coven](https://github.com/2389-research/coven) Rust project.
 
 ## Architecture
 
@@ -105,11 +108,15 @@ cp config.example.yaml config.yaml      # Copy config template
 4. Connection correlates responses by request_id, forwards to response channel
 5. `api.go` streams responses as SSE events to client
 
-**Binaries:**
+**Binaries (this repo):**
 
 - `coven-gateway` - Main server (gRPC + HTTP)
-- `coven-tui` - Interactive terminal client for testing
-- `coven-admin` - CLI for monitoring gateway status
+- `coven-admin` - CLI for gateway administration
+
+**Related binaries (from [coven](https://github.com/2389-research/coven) repo):**
+
+- `coven-tui` - Interactive terminal client
+- `coven-agent` - Agent that connects to this gateway
 
 ## gRPC Protocol
 
@@ -149,3 +156,47 @@ func TestSomething(t *testing.T) {
 - Context propagation for cancellation throughout
 - Interfaces for testability (Store, messageSender)
 - Error wrapping: `fmt.Errorf("context: %w", err)`
+
+## Error Handling Guidelines
+
+**Never ignore errors silently:**
+- Always check and handle errors from `json.Unmarshal`, `time.Parse`, `json.NewEncoder().Encode()`
+- Use `parseTimeWithWarning()` helper in store package for time parsing with logged warnings
+- Log errors at minimum; return them when possible
+
+**JSON encoding/decoding:**
+- Check `json.NewEncoder(w).Encode()` errors and log them
+- For JSON parsing from untrusted input, consider `DisallowUnknownFields()` for strict validation
+
+## Concurrency Guidelines
+
+**Channel safety:**
+- Only the producer should close a channel
+- Use `sync.Once` to guard channel close when multiple goroutines might attempt closure
+- Buffered channels (size 1+) prevent blocking on single-message scenarios
+
+**Timer management:**
+- Never use `time.After()` in loops (creates new timer each iteration, memory leak)
+- Use a reusable `time.Timer` with `Reset()` and proper `Stop()` + drain pattern:
+  ```go
+  timer := time.NewTimer(5 * time.Second)
+  defer timer.Stop()
+  for item := range items {
+      if !timer.Stop() {
+          select { case <-timer.C: default: }
+      }
+      timer.Reset(5 * time.Second)
+      // use timer...
+  }
+  ```
+
+**Nil checks:**
+- Always validate that injected dependencies (logger, stream, store) are non-nil
+- Provide sensible defaults: `if logger == nil { logger = slog.Default() }`
+
+## ID Generation
+
+**Use centralized ID generation:**
+- Principal IDs: Use `generatePrincipalID()` in `internal/admin/principals.go`
+- General UUIDs: Use `uuid.New().String()` from `github.com/google/uuid`
+- Never create timestamp-only IDs (collision risk under concurrent load)

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,20 @@
 # ABOUTME: Build and development commands for coven-gateway
 # ABOUTME: Handles proto generation, building, and testing
 
-.PHONY: all build build-gateway build-admin build-tui proto update-proto clean test lint fmt run setup hooks
+.PHONY: all build build-gateway build-admin proto update-proto clean test lint fmt run setup hooks
 
 # Default target
 all: proto build
 
 # Build all binaries
-build: build-gateway build-admin build-tui
+# Note: coven-tui is in the Rust coven repo: https://github.com/2389-research/coven
+build: build-gateway build-admin
 
 build-gateway:
 	go build -o bin/coven-gateway ./cmd/coven-gateway
 
 build-admin:
 	go build -o bin/coven-admin ./cmd/coven-admin
-
-build-tui:
-	go build -o bin/coven-tui ./cmd/coven-tui
 
 # Generate protobuf code from shared proto submodule
 proto:


### PR DESCRIPTION
## Summary

- Remove `build-tui` Makefile target - `coven-tui` is in the [coven](https://github.com/2389-research/coven) Rust repository
- Update CLAUDE.md proto path to correct submodule location (`proto/coven-proto/`)
- Clarify multi-repo architecture in documentation
- Add error handling, concurrency, and ID generation guidelines as prevention barriers

## Issue Investigation Results

Upon investigation of the open issues, I found that **most bugs had already been fixed**:

| Issue | Status | Notes |
|-------|--------|-------|
| #6 Silent errors | ✅ Already fixed | `parseTimeWithWarning()` helper exists, JSON encode errors logged |
| #8 Race conditions | ✅ Already fixed | `sync.Once` for channels, reusable timers, nil checks present |
| #10 ID collisions | ✅ Already fixed | `generatePrincipalID()` includes crypto/rand suffix |
| #19 Dead Makefile | ✅ Fixed in this PR | Removed `build-tui` target |

## Prevention Barriers Added

The coding guidelines in CLAUDE.md now codify these learnings to prevent similar issues:

**Error Handling:**
- Never ignore json/time parse errors
- Use `parseTimeWithWarning()` helper
- Log encoder errors

**Concurrency:**
- `sync.Once` for channel close
- Reusable timer pattern (avoid `time.After()` in loops)
- Nil checks for injected dependencies

**ID Generation:**
- Use centralized functions with random component
- Never timestamp-only IDs

## Test plan

- [x] `make build` succeeds without `build-tui`
- [x] `go test -race ./internal/...` passes
- [x] Pre-commit hooks pass

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded project documentation with new sections covering error handling guidelines, concurrency best practices, and ID generation patterns
  * Updated configuration context and command references

* **Chores**
  * Updated build system to reflect changes in binary organization across repositories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->