### PR TITLE
fix: resolve issues #48 and #49 — docs lint + token strict mode

### DIFF
--- a/docs/plans/2026-02-17-frontend-redesign-design.md
+++ b/docs/plans/2026-02-17-frontend-redesign-design.md
@@ -230,7 +230,7 @@ Container widths:
 The token build script (`web/scripts/build-tokens.ts`) generates:
 
 1. **`web/src/styles/generated/variables.css`** — `:root` and `[data-theme="dark"]` blocks
-2. **`web/src/styles/generated/tailwind.ts`** — Tailwind theme extension mapping tokens to `hsl(var(--color-*) / <alpha-value>)`
+2. **`web/src/styles/generated/theme.css`** — Tailwind v4 @theme block mapping semantic colors to utilities
 
 Theme switching is a `data-theme` attribute on `<html>`. No class toggling, no JS runtime cost.
 
@@ -249,6 +249,7 @@ Theme switching is a `data-theme` attribute on `<html>`. No class toggling, no J
 ### Component Inventory
 
 #### Layout
+
 | Component | Purpose | Priority |
 |-----------|---------|----------|
 | `AppShell` | Top-level layout: sidebar + header + main content | P0 |
@@ -260,6 +261,7 @@ Theme switching is a `data-theme` attribute on `<html>`. No class toggling, no J
 | `Panel` | Side panel (settings, details) with slide animation | P1 |
 
 #### Navigation
+
 | Component | Purpose | Priority |
 |-----------|---------|----------|
 | `SidebarNav` | Vertical nav with icons, groups, active state, collapse | P0 |
@@ -269,6 +271,7 @@ Theme switching is a `data-theme` attribute on `<html>`. No class toggling, no J
 | `Pagination` | Page navigation for lists | P2 |
 
 #### Data Display
+
 | Component | Purpose | Priority |
 |-----------|---------|----------|
 | `Table` | Headless data table with sorting, selection, virtual scroll | P0 |
@@ -282,6 +285,7 @@ Theme switching is a `data-theme` attribute on `<html>`. No class toggling, no J
 | `Avatar` | User/agent avatar with fallback initials | P2 |
 
 #### Inputs
+
 | Component | Purpose | Priority |
 |-----------|---------|----------|
 | `Button` | Primary/secondary/ghost/danger, sm/md/lg sizes | P0 |
@@ -296,6 +300,7 @@ Theme switching is a `data-theme` attribute on `<html>`. No class toggling, no J
 | `TagInput` | Multi-value input with tag chips | P2 |
 
 #### Overlays
+
 | Component | Purpose | Priority |
 |-----------|---------|----------|
 | `Dialog` | Modal dialog with focus trap, escape close | P0 |
@@ -305,6 +310,7 @@ Theme switching is a `data-theme` attribute on `<html>`. No class toggling, no J
 | `ContextMenu` | Right-click menu | P2 |
 
 #### Feedback
+
 | Component | Purpose | Priority |
 |-----------|---------|----------|
 | `Toast` | Temporary notification with auto-dismiss | P0 |
@@ -316,6 +322,7 @@ Theme switching is a `data-theme` attribute on `<html>`. No class toggling, no J
 | `ProgressBar` | Determinate/indeterminate progress | P2 |
 
 #### Real-time & Chat
+
 | Component | Purpose | Priority |
 |-----------|---------|----------|
 | `ChatThread` | Scrollable message list with auto-scroll, date separators | P0 |
@@ -329,6 +336,7 @@ Theme switching is a `data-theme` attribute on `<html>`. No class toggling, no J
 | `TokenCounter` | Token usage display with progress bar | P2 |
 
 #### Domain-Specific
+
 | Component | Purpose | Priority |
 |-----------|---------|----------|
 | `AgentList` | Filterable agent list with status, name, model | P0 |
@@ -413,7 +421,7 @@ export function createSSEStore<T>(url: string, parse: (data: string) => T) {
 
 ### Directory Structure
 
-```
+```text
 web/
 ├── tokens/
 │   └── tokens.json              <- Design token source of truth

--- a/docs/plans/frontend-redesign/RUNBOOK.md
+++ b/docs/plans/frontend-redesign/RUNBOOK.md
@@ -227,9 +227,9 @@ Phase N+1:
 
 1. **If you're about to type a second unrelated task in the same session, stop.** `/clear` or start a new session.
 
-2. **If Claude asks "should I also..." for something outside the current deliverable scope, say no.** Scope creep within a session is how context fills up.
+2. **When Claude asks "should I also..." for something outside the current deliverable scope, say no.** Scope creep within a session is how context fills up.
 
-3. **If a session has been running >20 minutes, assess whether to continue or commit and restart.** Long sessions degrade. Short focused sessions compound.
+3. **Long sessions degrade — assess at the 20-minute mark whether to continue or commit and restart.** Short focused sessions compound.
 
 4. **Always state what's already done.** Claude can't see git history efficiently. Tell it "deliverables 1-6 are committed" so it doesn't re-investigate.
 

--- a/docs/plans/frontend-redesign/phase-1-foundation.md
+++ b/docs/plans/frontend-redesign/phase-1-foundation.md
@@ -49,7 +49,7 @@ All of the following must pass before proceeding to Phase 2:
 
 ## Suggested Task Order
 
-```
+```text
 1. Initialize web/ project (Vite + Svelte 5 + TS)     ← scaffolding
 2. Token build script (variables.css only)              ← design foundation
 3. internal/assets/embed.go + ScriptTags()              ← Go integration

--- a/docs/plans/frontend-redesign/phase-5-login-auth.md
+++ b/docs/plans/frontend-redesign/phase-5-login-auth.md
@@ -34,6 +34,21 @@
 | Dark theme has too many contrast issues | Ship without dark theme. Add it as a separate Phase 5b after manual audit of all semantic token mappings against WCAG 2.1 AA. |
 | CSP breaks third-party integrations added later | Use `nonce`-based CSP instead of hash-based. Generate per-request nonces in Go, pass to template. |
 
+## CSP Mitigation for Island Props
+
+Svelte island components receive server-side props via `<script type="application/json">` blocks
+embedded in Go templates. Since `type="application/json"` blocks are not executable, they do not
+violate `script-src` CSP directives. However, the overall CSP policy uses nonce-based enforcement:
+
+- The Go server generates a per-request cryptographic nonce and passes it to the base template.
+- All executable `<script>` tags include `nonce="{{.CSPNonce}}"`.
+- The `Content-Security-Policy` header is set to `script-src 'nonce-<value>'` (no `'unsafe-inline'`).
+- `<script type="application/json">` blocks do not need a nonce because browsers do not execute them.
+- The island hydration script (`islands.ts`) reads the JSON data and passes it as props during mount.
+
+This approach satisfies CSP without requiring hash-based policies, and scales to any number of
+islands without per-component CSP bookkeeping.
+
 ## Bundle Budget
 
 | Asset | Limit (gzipped) |

--- a/docs/plans/frontend-redesign/phase-6-spa-evaluation.md
+++ b/docs/plans/frontend-redesign/phase-6-spa-evaluation.md
@@ -14,7 +14,7 @@ Proceed to SPA **only if** at least 3 of these conditions are true:
 | # | Condition | Evidence Required |
 |---|-----------|-------------------|
 | 1 | Cross-page state sharing is causing bugs or duplication | Documented instances of state sync issues between islands |
-| 2 | Page transitions are noticeably slow (full page reload) | User complaints or metrics showing > 500ms transition times |
+| 2 | Page transitions are noticeably slow (full-page reload) | User complaints or metrics showing > 500ms transition times |
 | 3 | Offline or optimistic UI is a product requirement | Feature request from users or product roadmap item |
 | 4 | Deep linking / browser history needs exceed what HTMX provides | Specific UX flows that require URL-driven client-side state |
 | 5 | The team has grown beyond 2 developers and can absorb the maintenance cost | Actual headcount, not projected |

--- a/web/scripts/build-tokens.test.ts
+++ b/web/scripts/build-tokens.test.ts
@@ -1,0 +1,103 @@
+// ABOUTME: Tests for build-tokens.ts strict mode and reference resolution.
+// ABOUTME: Validates resolveRefs handles valid refs, unresolved refs, and cyclic refs.
+
+import { describe, it, expect } from 'vitest';
+import { resolveRefs, flatten } from './build-tokens';
+
+describe('flatten', () => {
+  it('flattens nested objects into dot-delimited paths', () => {
+    const input = { color: { primary: { base: '210 100% 50%' } } };
+    expect(flatten(input)).toEqual({
+      'color.primary.base': '210 100% 50%',
+    });
+  });
+
+  it('returns empty object for non-object input', () => {
+    expect(flatten(null)).toEqual({});
+    expect(flatten('string')).toEqual({});
+  });
+});
+
+describe('resolveRefs', () => {
+  it('resolves valid references', () => {
+    const lookup = {
+      'color.blue': '210 100% 50%',
+      'color.primary': '{color.blue}',
+    };
+    const errors: string[] = [];
+    const result = resolveRefs('{color.blue}', lookup, errors);
+    expect(result).toBe('210 100% 50%');
+    expect(errors).toHaveLength(0);
+  });
+
+  it('resolves chained references', () => {
+    const lookup = {
+      'color.blue': '210 100% 50%',
+      'color.primary': '{color.blue}',
+      'color.accent': '{color.primary}',
+    };
+    const errors: string[] = [];
+    const result = resolveRefs('{color.accent}', lookup, errors);
+    expect(result).toBe('210 100% 50%');
+    expect(errors).toHaveLength(0);
+  });
+
+  it('returns raw value when no references are present', () => {
+    const errors: string[] = [];
+    const result = resolveRefs('16px', {}, errors);
+    expect(result).toBe('16px');
+    expect(errors).toHaveLength(0);
+  });
+
+  it('collects errors for unresolved references', () => {
+    const lookup = { 'color.blue': '210 100% 50%' };
+    const errors: string[] = [];
+    const result = resolveRefs('{color.missing}', lookup, errors);
+    expect(result).toBe('{color.missing}');
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('Unresolved token reference');
+    expect(errors[0]).toContain('color.missing');
+  });
+
+  it('collects errors for cyclic references', () => {
+    const lookup = {
+      'color.a': '{color.b}',
+      'color.b': '{color.a}',
+    };
+    const errors: string[] = [];
+    const result = resolveRefs('{color.a}', lookup, errors);
+    // The cycle will be detected when color.a is visited again
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    expect(errors.some((e) => e.includes('Cyclic token reference'))).toBe(true);
+  });
+
+  it('collects multiple errors from a single value', () => {
+    const errors: string[] = [];
+    const result = resolveRefs('{a.missing} and {b.missing}', {}, errors);
+    expect(result).toBe('{a.missing} and {b.missing}');
+    expect(errors).toHaveLength(2);
+  });
+
+  it('strict mode would fail when errors are present', () => {
+    // This test verifies the contract: if errors array is non-empty after
+    // resolution, strict mode should cause the build to fail. We test the
+    // errors collection mechanism that drives that decision.
+    const lookup = {
+      'valid.ref': 'ok',
+      'bad.chain': '{nonexistent}',
+    };
+    const errors: string[] = [];
+    resolveRefs('{valid.ref}', lookup, errors);
+    expect(errors).toHaveLength(0);
+
+    resolveRefs('{bad.chain}', lookup, errors);
+    // bad.chain resolves to '{nonexistent}' which then fails to resolve
+    expect(errors.length).toBeGreaterThan(0);
+
+    // This is the condition checked in strict mode
+    const wouldFail = process.env.TOKENS_STRICT === '1' && errors.length > 0;
+    // In test context TOKENS_STRICT is not set, so wouldFail is false,
+    // but the errors array correctly captures the problems
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/web/scripts/build-tokens.test.ts
+++ b/web/scripts/build-tokens.test.ts
@@ -1,8 +1,8 @@
-// ABOUTME: Tests for build-tokens.ts strict mode and reference resolution.
-// ABOUTME: Validates resolveRefs handles valid refs, unresolved refs, and cyclic refs.
+// ABOUTME: Tests for token-utils.ts — pure functions used by build-tokens.ts.
+// ABOUTME: Validates flatten and resolveRefs handle valid refs, unresolved refs, and cyclic refs.
 
 import { describe, it, expect } from 'vitest';
-import { resolveRefs, flatten } from './build-tokens';
+import { resolveRefs, flatten } from './token-utils';
 
 describe('flatten', () => {
   it('flattens nested objects into dot-delimited paths', () => {
@@ -78,10 +78,7 @@ describe('resolveRefs', () => {
     expect(errors).toHaveLength(2);
   });
 
-  it('strict mode would fail when errors are present', () => {
-    // This test verifies the contract: if errors array is non-empty after
-    // resolution, strict mode should cause the build to fail. We test the
-    // errors collection mechanism that drives that decision.
+  it('accumulates errors across multiple resolveRefs calls with shared array', () => {
     const lookup = {
       'valid.ref': 'ok',
       'bad.chain': '{nonexistent}',
@@ -91,13 +88,10 @@ describe('resolveRefs', () => {
     expect(errors).toHaveLength(0);
 
     resolveRefs('{bad.chain}', lookup, errors);
-    // bad.chain resolves to '{nonexistent}' which then fails to resolve
     expect(errors.length).toBeGreaterThan(0);
 
-    // This is the condition checked in strict mode
-    const wouldFail = process.env.TOKENS_STRICT === '1' && errors.length > 0;
-    // In test context TOKENS_STRICT is not set, so wouldFail is false,
-    // but the errors array correctly captures the problems
-    expect(errors.length).toBeGreaterThan(0);
+    // A second bad call appends to the same array
+    resolveRefs('{also.missing}', lookup, errors);
+    expect(errors.length).toBeGreaterThan(1);
   });
 });

--- a/web/scripts/build-tokens.ts
+++ b/web/scripts/build-tokens.ts
@@ -1,3 +1,6 @@
+// ABOUTME: Reads tokens.json and generates CSS custom properties and Tailwind v4 theme files.
+// ABOUTME: Supports TOKENS_STRICT=1 env var to fail on unresolved or cyclic token references.
+
 /**
  * Reads tokens.json and generates:
  *   1. variables.css — CSS custom properties for all tokens
@@ -20,7 +23,7 @@ const THEME_PATH = resolve(OUTPUT_DIR, 'theme.css');
 const tokens = JSON.parse(readFileSync(TOKENS_PATH, 'utf-8'));
 
 // Flatten a nested object into path→value pairs: { "a.b.c": "value" }
-function flatten(obj: unknown, prefix = ''): Record<string, string> {
+export function flatten(obj: unknown, prefix = ''): Record<string, string> {
   const result: Record<string, string> = {};
   if (typeof obj !== 'object' || obj === null) return result;
   for (const [key, value] of Object.entries(obj)) {
@@ -36,21 +39,31 @@ function flatten(obj: unknown, prefix = ''): Record<string, string> {
 
 // Resolve {path.to.value} references against a flat lookup.
 // Tracks visited refs to prevent infinite recursion on cyclic references.
-function resolveRefs(value: string, lookup: Record<string, string>, visited = new Set<string>()): string {
+// Collects error messages into the provided errors array for strict mode enforcement.
+export function resolveRefs(
+  value: string,
+  lookup: Record<string, string>,
+  errors: string[] = [],
+  visited = new Set<string>(),
+): string {
   return value.replace(/\{([^}]+)\}/g, (_, ref: string) => {
     if (visited.has(ref)) {
-      console.warn(`Cyclic token reference detected: {${ref}}`);
+      const msg = `Cyclic token reference detected: {${ref}}`;
+      console.warn(msg);
+      errors.push(msg);
       return `{${ref}}`;
     }
     const resolved = lookup[ref];
     if (resolved === undefined) {
-      console.warn(`Unresolved token reference: {${ref}}`);
+      const msg = `Unresolved token reference: {${ref}}`;
+      console.warn(msg);
+      errors.push(msg);
       return `{${ref}}`;
     }
     // Recursively resolve in case of chained references
     const next = new Set(visited);
     next.add(ref);
-    return resolveRefs(resolved, lookup, next);
+    return resolveRefs(resolved, lookup, errors, next);
   });
 }
 
@@ -76,10 +89,20 @@ function wrapHsl(value: string): string {
 // Build the full flat lookup for reference resolution
 const allFlat = flatten(tokens);
 
-// Resolve all references
+// Resolve all references, collecting any errors for strict mode
+const tokenErrors: string[] = [];
 const resolved: Record<string, string> = {};
 for (const [key, value] of Object.entries(allFlat)) {
-  resolved[key] = resolveRefs(value, allFlat);
+  resolved[key] = resolveRefs(value, allFlat, tokenErrors);
+}
+
+// In strict mode (TOKENS_STRICT=1), fail the build on any unresolved or cyclic references
+if (process.env.TOKENS_STRICT === '1' && tokenErrors.length > 0) {
+  console.error(`\nStrict mode: ${tokenErrors.length} token reference error(s) found:`);
+  for (const err of tokenErrors) {
+    console.error(`  - ${err}`);
+  }
+  process.exit(1);
 }
 
 // Group tokens for output

--- a/web/scripts/build-tokens.ts
+++ b/web/scripts/build-tokens.ts
@@ -13,6 +13,7 @@
 
 import { readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { resolve, dirname } from 'path';
+import { flatten, resolveRefs } from './token-utils';
 
 const TOKENS_PATH = resolve(import.meta.dirname!, '..', 'tokens', 'tokens.json');
 const OUTPUT_DIR = resolve(import.meta.dirname!, '..', 'src', 'styles', 'generated');
@@ -21,51 +22,6 @@ const THEME_PATH = resolve(OUTPUT_DIR, 'theme.css');
 
 // Read and parse tokens
 const tokens = JSON.parse(readFileSync(TOKENS_PATH, 'utf-8'));
-
-// Flatten a nested object into path→value pairs: { "a.b.c": "value" }
-export function flatten(obj: unknown, prefix = ''): Record<string, string> {
-  const result: Record<string, string> = {};
-  if (typeof obj !== 'object' || obj === null) return result;
-  for (const [key, value] of Object.entries(obj)) {
-    const path = prefix ? `${prefix}.${key}` : key;
-    if (typeof value === 'object' && value !== null) {
-      Object.assign(result, flatten(value, path));
-    } else {
-      result[path] = String(value);
-    }
-  }
-  return result;
-}
-
-// Resolve {path.to.value} references against a flat lookup.
-// Tracks visited refs to prevent infinite recursion on cyclic references.
-// Collects error messages into the provided errors array for strict mode enforcement.
-export function resolveRefs(
-  value: string,
-  lookup: Record<string, string>,
-  errors: string[] = [],
-  visited = new Set<string>(),
-): string {
-  return value.replace(/\{([^}]+)\}/g, (_, ref: string) => {
-    if (visited.has(ref)) {
-      const msg = `Cyclic token reference detected: {${ref}}`;
-      console.warn(msg);
-      errors.push(msg);
-      return `{${ref}}`;
-    }
-    const resolved = lookup[ref];
-    if (resolved === undefined) {
-      const msg = `Unresolved token reference: {${ref}}`;
-      console.warn(msg);
-      errors.push(msg);
-      return `{${ref}}`;
-    }
-    // Recursively resolve in case of chained references
-    const next = new Set(visited);
-    next.add(ref);
-    return resolveRefs(resolved, lookup, errors, next);
-  });
-}
 
 // Convert a flat key to CSS var name.
 // Color tokens get --cg-* prefix; non-color tokens get --{category}-* prefix.

--- a/web/scripts/token-utils.ts
+++ b/web/scripts/token-utils.ts
@@ -1,0 +1,47 @@
+// ABOUTME: Pure utility functions for token resolution used by build-tokens.ts.
+// ABOUTME: Extracted to avoid module-level side effects when imported in tests.
+
+// Flatten a nested object into path→value pairs: { "a.b.c": "value" }
+export function flatten(obj: unknown, prefix = ''): Record<string, string> {
+  const result: Record<string, string> = {};
+  if (typeof obj !== 'object' || obj === null) return result;
+  for (const [key, value] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === 'object' && value !== null) {
+      Object.assign(result, flatten(value, path));
+    } else {
+      result[path] = String(value);
+    }
+  }
+  return result;
+}
+
+// Resolve {path.to.value} references against a flat lookup.
+// Tracks visited refs to prevent infinite recursion on cyclic references.
+// Collects error messages into the provided errors array for strict mode enforcement.
+export function resolveRefs(
+  value: string,
+  lookup: Record<string, string>,
+  errors: string[] = [],
+  visited = new Set<string>(),
+): string {
+  return value.replace(/\{([^}]+)\}/g, (_, ref: string) => {
+    if (visited.has(ref)) {
+      const msg = `Cyclic token reference detected: {${ref}}`;
+      console.warn(msg);
+      errors.push(msg);
+      return `{${ref}}`;
+    }
+    const resolved = lookup[ref];
+    if (resolved === undefined) {
+      const msg = `Unresolved token reference: {${ref}}`;
+      console.warn(msg);
+      errors.push(msg);
+      return `{${ref}}`;
+    }
+    // Recursively resolve in case of chained references
+    const next = new Set(visited);
+    next.add(ref);
+    return resolveRefs(resolved, lookup, errors, next);
+  });
+}

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
-    include: ['src/**/*.{test,spec}.{ts,js}'],
+    include: ['src/**/*.{test,spec}.{ts,js}', 'scripts/**/*.{test,spec}.{ts,js}'],
     setupFiles: ['./test/setup.ts'],
     globals: true,
   },


### PR DESCRIPTION
## Summary

- **#48**: Fix markdown lint issues across frontend redesign docs (MD040 code fence tags, MD058 table spacing, compound adjective hyphenation, varied sentence openings, corrected generated file reference)
- **#49**: Add `TOKENS_STRICT=1` env var to `web/scripts/build-tokens.ts` that fails the build on unresolved/cyclic token references. Includes 9 Vitest tests and CSP mitigation docs for island props.

Closes #48
Closes #49

## Test plan

- [x] All Go tests pass (`go test ./...`)
- [x] All Vitest tests pass (95 tests across 14 suites)
- [x] Token build script works in default mode (warn + continue)
- [x] `TOKENS_STRICT=1` causes exit(1) on bad references
- [x] Markdown lint issues verified fixed in affected files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded frontend redesign docs with a much larger component inventory, updated directory structure display, CSS-first token pipeline and design-token output moved to a CSS theme file, plus new CSP mitigation guidance for island props and phrasing refinements for session/scope guidance.
* **Tests**
  * Added comprehensive tests for token resolution and build behavior.
* **Chores**
  * Expanded test discovery to include script test files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->